### PR TITLE
Bug: Homepage routing fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,5 +13,6 @@ if (isGithubActions) {
 module.exports = {
   assetPrefix: assetPrefix,
   basePath: basePath,
+  trailingSlash: true,
   output: 'export',
 }


### PR DESCRIPTION
<Update pull_request_template.md to change this template>
<Delete any sections below that are not applicable>

# Description

Issue: #10

- [x] Added `"homepage": "https://mitxpro-dev.github.io/learnjs/"` to `package.json` to attempt to fix routing 

# Screenshots

<details>
 <summary>Click here for screenshots</summary>

<Add screenshots here>
None yet!

</details>

# Notes

Failed to reproduce this issue locally. In the browser, this link renders correctly with the `href` pointing to `/`. It is suspected that when deployed to GH actions, the base URL is incorrect.

My money is on the regex in `next.config.js` however I tested that with the github repo name and that seemed to be OK. I did fix a similar problem in the past by adding `homepage` to the `package.json` so that's my first attempt. I'll replace the regex with a hardcoded value next to see if that fixes it.

<Add any additional notes here>
