### PR TITLE
Feat/Add nav and layout max width

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang='en'>
-      <body className={inter.className}>
+      <body className={inter.className} style={{ maxWidth: '1440px', margin: 'auto'}}>
         <Providers>
           <Navigation />
           {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,10 +17,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang='en'>
-      <body className={inter.className} style={{ maxWidth: '1440px', margin: 'auto'}}>
+      <body className={inter.className}>
         <Providers>
           <Navigation />
-          {children}
+          <div style={{ maxWidth: '1440px', margin: 'auto'}}>
+            {children}
+          </div>
           <Footer />
         </Providers>
       </body>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,7 +44,8 @@ export const Navigation = () => {
 
   return (
     <>
-      <Box bg={useColorModeValue('gray.100', 'gray.900')} position='fixed' px={4} w='100%' maxW='1440px'>
+      <Box bg={useColorModeValue('gray.100', 'gray.900')} position='fixed' px={4} w='100%'>
+        <Box maxW='1440px' margin='auto'>
         <Flex h={12} alignItems={'center'} justifyContent={'space-between'}>
           <IconButton
             size={'md'}
@@ -87,6 +88,7 @@ export const Navigation = () => {
             </Stack>
           </Box>
         ) : null}
+        </Box>
       </Box>
     </>
   )

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,8 +44,8 @@ export const Navigation = () => {
 
   return (
     <>
-      <Box bg={useColorModeValue('gray.100', 'gray.900')} position='fixed' px={4} w='100%'>
-        <Flex h={16} alignItems={'center'} justifyContent={'space-between'}>
+      <Box bg={useColorModeValue('gray.100', 'gray.900')} position='fixed' px={4} w='100%' maxW='1440px'>
+        <Flex h={10} alignItems={'center'} justifyContent={'space-between'}>
           <IconButton
             size={'md'}
             icon={
@@ -64,7 +64,7 @@ export const Navigation = () => {
             aria-label={'Navigation menu'}
           />
           <HStack spacing={8} alignItems={'center'}>
-            <Box>Learn JS</Box>
+            <Box fontWeight='bold'>Learn JS</Box>
             <HStack
               as={'nav'}
               spacing={4}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -45,7 +45,7 @@ export const Navigation = () => {
   return (
     <>
       <Box bg={useColorModeValue('gray.100', 'gray.900')} position='fixed' px={4} w='100%' maxW='1440px'>
-        <Flex h={10} alignItems={'center'} justifyContent={'space-between'}>
+        <Flex h={12} alignItems={'center'} justifyContent={'space-between'}>
           <IconButton
             size={'md'}
             icon={


### PR DESCRIPTION
<Update pull_request_template.md to change this template>
<Delete any sections below that are not applicable>

# Description

- [x] Set a max-width of `1440px` for the navigation and page layout
  - This is intended to ensure that the page is not stretched out horizontally on ultra wide monitors
- [x] Reduce the navigation height
  - The navigation seemed to take up a lot of vertical space, reduced this from `16` to `12`

# Screenshots

<details>
 <summary>Click here for screenshots</summary>

> Note: screenshots below simulated an ultra wide monitor by zooming out a lot

#### Before
<img width="1512" alt="Screenshot 2023-07-01 at 11 50 11 AM" src="https://github.com/mitxpro-dev/learnjs/assets/96446064/b90e2ef5-067c-46a0-9030-9d3886159ae2">

#### After
<img width="1511" alt="Screenshot 2023-07-01 at 12 37 31 PM" src="https://github.com/mitxpro-dev/learnjs/assets/96446064/638a58f6-9226-4d02-87b0-ad9873f4aeac">

<Add screenshots here>

</details>
