### PR TITLE
bug: fix blank page and base URL in prod

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,5 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
-  base: '/',
+  base: process.env.NODE_ENV === 'production' ? '/learnjs/' : '/',
 })


### PR DESCRIPTION
<Update pull_request_template.md to change this template>
Resolves #37 

<Delete any sections below that are not applicable>

# Description

Issue: #37

- [x] Added check for environment to dynamically select base URL

# Screenshots

<details>
 <summary>Click here for screenshots</summary>

N/A

</details>

# Notes

On localhost, the routing is based at `/`, but on GH pages the routing is based at `/learnjs/`. To allow the app to run both locally and in prod, I added a check for an environment variable automatically set by node at buildtime called `NODE_ENV`. When building in dev mode for local testing, the variable will be automatically set to `development`. When building the project for deployment, it'll automatically populate as `production`.